### PR TITLE
feat: 전체수집 및 필터 및 dedup 적용 (#8)

### DIFF
--- a/src/main/java/com/seoulhousing/ingest_core/external/myhome/service/MyHomeAnnouncementCollectService.java
+++ b/src/main/java/com/seoulhousing/ingest_core/external/myhome/service/MyHomeAnnouncementCollectService.java
@@ -1,14 +1,17 @@
 package com.seoulhousing.ingest_core.external.myhome.service;
 
+
 import com.seoulhousing.ingest_core.external.myhome.client.MyHomeApiClient;
+import com.seoulhousing.ingest_core.external.myhome.dto.LtRsdtListRequest;
 import com.seoulhousing.ingest_core.external.myhome.dto.MyHomeItemDto;
+import com.seoulhousing.ingest_core.external.myhome.dto.MyHomeListResponse;
 import com.seoulhousing.ingest_core.external.myhome.dto.RsdtListRequest;
+import com.seoulhousing.ingest_core.external.myhome.service.filter.RegionFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Service
 public class MyHomeAnnouncementCollectService {
@@ -21,39 +24,199 @@ public class MyHomeAnnouncementCollectService {
         this.myHomeApiClient = myHomeApiClient;
     }
 
-    //공공임대 공고를 전부 가져온뒤 , 원하는 지역만 필터링해서 반환하기
-    public List<MyHomeItemDto> collectRsdt(RsdtListRequest baseRequest RegionFilter filter) {}
+    // 공공임대 수집
+    public List<MyHomeItemDto> collectRsdt(RsdtListRequest baseRequest, RegionFilter filter) {
+        Objects.requireNonNull(baseRequest, "baseRequest must not be null");
+        Objects.requireNonNull(filter, "filter must not be null");
 
+        // 전체 수집하기
+        List<MyHomeItemDto> all = fetchAllRsdtPages(baseRequest);
 
-    public static class RegionFilter{
+        // 필터 적용해주기
+        List<MyHomeItemDto> filtered = all.stream()
+                .filter(filter::matches)
+                .toList();
 
-        private final Set<String> brtcNormalized;
+        // 중복 제거하기
+        List<MyHomeItemDto> deduped = dedupByStdId(filtered, "RSDT");
 
-        public RegionFilter(Set<String> brtcNormalized) {
-            this.brtcNormalized = brtcNormalized;
+        log.info("[MyHome][RSDT] collected={} filtered={} deduped={}",
+                all.size(), filtered.size(), deduped.size());
+
+        return deduped;
+    }
+
+    // 공공분양 수집
+    public List<MyHomeItemDto> collectLtRsdt(LtRsdtListRequest baseRequest, RegionFilter filter) {
+        Objects.requireNonNull(baseRequest, "baseRequest must not be null");
+        Objects.requireNonNull(filter, "filter must not be null");
+
+        List<MyHomeItemDto> all = fetchAllLtRsdtPages(baseRequest);
+
+        List<MyHomeItemDto> filtered = all.stream()
+                .filter(filter::matches)
+                .toList();
+
+        List<MyHomeItemDto> deduped = dedupByStdId(filtered, "LTRSDT");
+
+        log.info("[MyHome][LTRSDT] collected={} filtered={} deduped={}",
+                all.size(), filtered.size(), deduped.size());
+
+        return deduped;
+    }
+
+    // 전체 수집하는 루프
+    private List<MyHomeItemDto> fetchAllRsdtPages(RsdtListRequest base) {
+        List<MyHomeItemDto> acc = new ArrayList<>();
+
+        // 페이지 시작 숫자 및 몇개 가져올지 최대페이지(무한루프 방지를 위해서) 지정
+        int pageNo = 1;
+        int numOfRows = base.getNumOfRows();
+        final int maxPages = 200;
+
+        while (true) {
+            // 불변객체를 빌더 패턴으로 재구성
+            RsdtListRequest req = RsdtListRequest.builder()
+                    .pageNo(pageNo)
+                    .numOfRows(numOfRows)
+                    .brtcCode(base.getBrtcCode())
+                    .signguCode(base.getSignguCode())
+                    .houseTy(base.getHouseTy())
+                    .yearMtBegin(base.getYearMtBegin())
+                    .yearMtEnd(base.getYearMtEnd())
+
+                    // rsdt 전용 조건
+                    .suplyTy(base.getSuplyTy())
+                    .lfstsTyAt(base.getLfstsTyAt())
+                    .bassMtRntchrgSe(base.getBassMtRntchrgSe())
+                    .build();
+
+            // 외부 호출은 client로 위임
+            MyHomeListResponse res = myHomeApiClient.fetchRsdt(req);
+
+            // items 안전하게 확보해주기
+            List<MyHomeItemDto> items = res.itemsOrEmpty();
+            acc.addAll(items);
+
+            // 빈 배열이면 종료
+            if (items.isEmpty()) break;
+
+            // totalCount 기반 종료
+            int totalCount = parseIntOrMinus1(res.totalCountOrNull());
+            if (totalCount > -1) {
+                int fetched = pageNo * numOfRows;
+                if (fetched >= totalCount) break;
+            }
+
+            // 마지막 페이지는 보통 원래 개수보다 부족하니까 아래와 같은 코드 작성하였음
+            if (items.size() < numOfRows) break;
+
+            // 무한루프 방지하기
+            if (pageNo >= maxPages) {
+                log.error("[MyHome][RSDT] paging aborted: exceeded maxPages={}", maxPages);
+                break;
+            }
+
+            pageNo++;
         }
 
-        // 전국(혹시 확장성이 있을수도 있으니 설정)
-        public static RegionFilter all() {
-            return new RegionFilter(Collections.emptySet());
+        return acc;
+    }
+
+    private List<MyHomeItemDto> fetchAllLtRsdtPages(LtRsdtListRequest base) {
+        List<MyHomeItemDto> acc = new ArrayList<>();
+
+        int pageNo = 1;
+        int numOfRows = base.getNumOfRows();
+        final int maxPages = 200;
+
+        while (true) {
+            LtRsdtListRequest req = LtRsdtListRequest.builder()
+                    .pageNo(pageNo)
+                    .numOfRows(numOfRows)
+                    .brtcCode(base.getBrtcCode())
+                    .signguCode(base.getSignguCode())
+                    .houseTy(base.getHouseTy())
+                    .yearMtBegin(base.getYearMtBegin())
+                    .yearMtEnd(base.getYearMtEnd())
+                    .build();
+
+            MyHomeListResponse res = myHomeApiClient.fetchLtRsdt(req);
+
+            List<MyHomeItemDto> items = res.itemsOrEmpty();
+            acc.addAll(items);
+
+            if (items.isEmpty()) break;
+
+            int totalCount = parseIntOrMinus1(res.totalCountOrNull());
+            if (totalCount > -1) {
+                int fetched = pageNo * numOfRows;
+                if (fetched >= totalCount) break;
+            }
+
+            if (items.size() < numOfRows) break;
+
+            if (pageNo >= maxPages) {
+                log.error("[MyHome][LTRSDT] paging aborted: exceeded maxPages={}", maxPages);
+                break;
+            }
+
+            pageNo++;
         }
 
-        // 시도명으로 필터 생성
-        public static RegionFilter ofBrtcPrefixes(Collection<String> prefixes) {
-            if(prefixes == null || prefixes.isEmpty()) return all();
+        return acc;
+    }
 
-            Set<String> normalized = prefixes.stream()
-                    .filter(Objects::nonNull)
-                    .map(RegionFilter::normalize)
-                    .filter(s -> !s.isBlank())
-                    .collect(Collectors.toCollection(LinkedHashSet::new));
+    //스트링으로 오는 값 처리
+    private static int parseIntOrMinus1(String s) {
+        if (s == null || s.isBlank()) return -1;
+        try {
+            return Integer.parseInt(s.trim());
+        } catch (Exception e) {
+            return -1;
+        }
+    }
 
-            return new RegionFilter(normalized);
+    // 혹시 모를 중복 방어해주기
+    private List<MyHomeItemDto> dedupByStdId(List<MyHomeItemDto> items, String category) {
+        Map<String, MyHomeItemDto> map = new LinkedHashMap<>(); // 순서 유지
+
+        for (MyHomeItemDto it : items) {
+            if (it == null) continue;
+
+            String pblancId = safe(it.getPblancId());
+            String houseSn = safe(it.getHouseSn());
+
+            // pblancId 없으면 데이터 자체가 깨진 것이므로 그만 남기고 스킵해주기
+            if (pblancId.isBlank()) {
+                log.warn("[MyHome][{}] missing pblancId. item={}", category, it);
+                continue;
+            }
+
+            if (houseSn.isBlank()) {
+                log.warn("[MyHome][{}] missing houseSn. skip. pblancId={}, brtc={}, signgu={}",
+                        category, pblancId, safe(it.getBrtcNm()), safe(it.getSignguNm()));
+                continue;
+            }
+
+            String stdId = "myhome:" + category.toLowerCase() + ":" + pblancId + ":" + houseSn;
+
+            MyHomeItemDto prev = map.putIfAbsent(stdId, it);
+            if (prev != null) {
+                // 중복이면 지역 정보가 다른지 로그로 찍기
+                log.warn("[MyHome][{}] duplicate stdId detected. stdId={}, brtc(prev={}, now={}), signgu(prev={}, now={})",
+                        category,
+                        stdId,
+                        safe(prev.getBrtcNm()), safe(it.getBrtcNm()),
+                        safe(prev.getSignguNm()), safe(it.getSignguNm())
+                );
+            }
         }
 
-        // 실제로 아이템이 필터에 매칭이 되었는지 판정하는 함수
-        public boolean matches(MyHomeItemDto item) {
-            if(brtcNormalized)
-        }
+        return new ArrayList<>(map.values());
+    }
+
+    private static String safe(String s) {
+        return s == null ? "" : s.trim();
     }
 }

--- a/src/main/java/com/seoulhousing/ingest_core/external/myhome/service/filter/AllRegionFilter.java
+++ b/src/main/java/com/seoulhousing/ingest_core/external/myhome/service/filter/AllRegionFilter.java
@@ -1,0 +1,11 @@
+package com.seoulhousing.ingest_core.external.myhome.service.filter;
+
+import com.seoulhousing.ingest_core.external.myhome.dto.MyHomeItemDto;
+
+// 필터 없음(전국)
+public class AllRegionFilter implements RegionFilter{
+    @Override
+    public boolean matches(MyHomeItemDto item) {
+        return true;
+    }
+}

--- a/src/main/java/com/seoulhousing/ingest_core/external/myhome/service/filter/BrtcRegionFilter.java
+++ b/src/main/java/com/seoulhousing/ingest_core/external/myhome/service/filter/BrtcRegionFilter.java
@@ -1,0 +1,50 @@
+package com.seoulhousing.ingest_core.external.myhome.service.filter;
+
+import com.seoulhousing.ingest_core.external.myhome.dto.MyHomeItemDto;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class BrtcRegionFilter implements RegionFilter {
+
+    private final Set<String> prefixesNormalized;
+
+    public BrtcRegionFilter(Collection<String> prefixes){
+
+        // 입력을 정규화하여 안전하게 보관하기
+        Set<String> set = new LinkedHashSet<>();
+        if(prefixes != null){
+            for (String p : prefixes) {
+                if(p == null) continue;
+                String n = normalize(p);
+                if(!n.isBlank()) set.add(n);
+            }
+        }
+
+        if (set.isEmpty()) {
+            throw new IllegalArgumentException("BrtcRegionFilter prefixes must not be empty. Use AllRegionFilter for ALL scope.");
+        }
+
+        this.prefixesNormalized = Set.copyOf(set);
+    }
+
+    @Override
+    public boolean matches(MyHomeItemDto item) {
+
+        String brtc = normalize(item == null ? null : item.getBrtcNm());
+        if (brtc.isBlank()) return false;
+
+        for (String prefix : prefixesNormalized) {
+            if (brtc.startsWith(prefix)) return true;
+        }
+        return false;
+    }
+
+
+    // 혹시 모르는 공백형태 제거해주는 최소 정규화 적용하기
+    private static String normalize(String s) {
+        if (s == null) return "";
+        return s.trim().replace(" ", "");
+    }
+}

--- a/src/main/java/com/seoulhousing/ingest_core/external/myhome/service/filter/RegionFilter.java
+++ b/src/main/java/com/seoulhousing/ingest_core/external/myhome/service/filter/RegionFilter.java
@@ -1,0 +1,9 @@
+package com.seoulhousing.ingest_core.external.myhome.service.filter;
+
+import com.seoulhousing.ingest_core.external.myhome.dto.MyHomeItemDto;
+
+public interface RegionFilter {
+
+    // 지역 판정 로직
+    boolean matches(MyHomeItemDto item);
+}


### PR DESCRIPTION
전체 공고를 끝까지 수집하고 서울 필터를 적용하도록 정리했습니다.지역 조건은 RegionFilter 인터페이스로 분리해 서울 또는 전국 같은 요구 변경을 필터 교체만으로 대응할 수 있게 했습니다.중복 응답 가능성을 고려해 pblancId와 houseSn 기준으로 중복 제거도 추가했습니다.